### PR TITLE
Convert some UI text to Traditional Chinese

### DIFF
--- a/packages/react-app/src/components/app-edit-drawer.tsx
+++ b/packages/react-app/src/components/app-edit-drawer.tsx
@@ -68,7 +68,7 @@ export const AppEditDrawer = (props: IAppEditDrawerProps) => {
 			manual: true,
 			onSuccess: () => {
 				onClose?.()
-				message.success('新增应用配置成功')
+                                message.success('新增應用配置成功')
 			},
 		},
 	)
@@ -81,7 +81,7 @@ export const AppEditDrawer = (props: IAppEditDrawerProps) => {
 			manual: true,
 			onSuccess: () => {
 				onClose?.()
-				message.success('编辑应用配置成功')
+                                message.success('編輯應用配置成功')
 			},
 		},
 	)
@@ -89,7 +89,7 @@ export const AppEditDrawer = (props: IAppEditDrawerProps) => {
 	return (
 		<Drawer
 			width={700}
-			title={`${detailDrawerMode === AppDetailDrawerModeEnum.create ? '新增应用配置' : `编辑应用配置 - ${appItem?.info.name}`}`}
+                        title={`${detailDrawerMode === AppDetailDrawerModeEnum.create ? '新增應用配置' : `編輯應用配置 - ${appItem?.info.name}`}`}
 			open={open}
 			onClose={onClose}
 			extra={
@@ -151,14 +151,14 @@ export const AppEditDrawer = (props: IAppEditDrawerProps) => {
 								}
 								confirmCallback?.()
 							} catch (error) {
-								console.error('保存应用配置失败', error)
-								message.error(`保存应用配置失败: ${error}`)
+                                                                console.error('保存應用配置失敗', error)
+                                                                message.error(`保存應用配置失敗: ${error}`)
 							} finally {
 								setConfirmBtnLoading(false)
 							}
 						}}
 					>
-						{detailDrawerMode === AppDetailDrawerModeEnum.create ? '确定' : '更新'}
+                                                {detailDrawerMode === AppDetailDrawerModeEnum.create ? '確定' : '更新'}
 					</Button>
 				</Space>
 			}

--- a/packages/react-app/src/components/app-list.tsx
+++ b/packages/react-app/src/components/app-list.tsx
@@ -67,21 +67,21 @@ export default function AppList(props: IAppListProps) {
 									items: [
 										{
 											key: 'update',
-											label: '更新配置',
+                                                                               label: '更新配置',
 											onClick: async event => {
 												event.domEvent.stopPropagation()
 												await onUpdate?.(item.id, item)
-												message.success('更新应用配置成功')
+                                                                               message.success('更新應用配置成功')
 											},
 										},
 										{
 											key: 'delete',
-											label: '删除',
+                                                                               label: '刪除',
 											danger: true,
 											onClick: async event => {
 												event.domEvent.stopPropagation()
 												await onDelete(item.id)
-												message.success('删除应用成功')
+                                                                               message.success('刪除應用成功')
 											},
 										},
 									],

--- a/packages/react-app/src/components/chatbox-wrapper.tsx
+++ b/packages/react-app/src/components/chatbox-wrapper.tsx
@@ -294,12 +294,12 @@ export default function ChatboxWrapper(props: IChatboxWrapperProps) {
 	if (!currentApp) {
 		return (
 			<div className="w-full h-full flex items-center justify-center">
-				<Empty description="请先配置 Dify 应用">
+                                <Empty description="請先配置 Dify 應用">
 					<Button
 						type="primary"
 						onClick={handleStartConfig}
 					>
-						开始配置
+                                                開始配置
 					</Button>
 				</Empty>
 			</div>

--- a/packages/react-app/src/components/setting-form.tsx
+++ b/packages/react-app/src/components/setting-form.tsx
@@ -30,104 +30,104 @@ export default function SettingForm(props: ISettingFormProps) {
 		>
 			<div className="text-base mb-3 flex items-center">
 				<div className="h-4 w-1 bg-primary rounded"></div>
-				<div className="ml-2 font-semibold">请求配置</div>
+                                <div className="ml-2 font-semibold">請求配置</div>
 			</div>
 			<Form.Item
 				label="API Base"
 				name="apiBase"
-				rules={[{ required: true, message: 'API Base 不能为空' }]}
+                                rules={[{ required: true, message: 'API Base 不能為空' }]}
 				tooltip="Dify API 的域名+版本号前缀，如 https://api.dify.ai/v1"
 				required
 			>
 				<Input
 					autoComplete="new-password"
-					placeholder="请输入 API BASE"
+                                        placeholder="請輸入 API BASE"
 				/>
 			</Form.Item>
 			<Form.Item
 				label="API Secret"
 				name="apiKey"
-				tooltip="Dify App 的 API Secret (以 app- 开头)"
-				rules={[{ required: true, message: 'API Secret 不能为空' }]}
+                                tooltip="Dify App 的 API Secret (以 app- 開頭)"
+                                rules={[{ required: true, message: 'API Secret 不能為空' }]}
 				required
 			>
 				<Input.Password
 					autoComplete="new-password"
-					placeholder="请输入 API Secret"
+                                        placeholder="請輸入 API Secret"
 				/>
 			</Form.Item>
 
 			<div className="text-base mb-3 flex items-center">
 				<div className="h-4 w-1 bg-primary rounded"></div>
-				<div className="ml-2 font-semibold">基本信息</div>
+                                <div className="ml-2 font-semibold">基本資訊</div>
 			</div>
 			<Form.Item
 				name="info.name"
-				label="应用名称"
+                                label="應用名稱"
 				hidden={mode === AppDetailDrawerModeEnum.create}
 			>
 				<Input
 					disabled
-					placeholder="请输入应用名称"
+                                        placeholder="請輸入應用名稱"
 				/>
 			</Form.Item>
 			<Form.Item
 				name="info.mode"
-				label="应用类型"
-				tooltip="小于或等于 v1.3.1 的 Dify API 不会返回应用类型字段，需要用户自行选择"
+                                label="應用類型"
+                                tooltip="小於或等於 v1.3.1 的 Dify API 不會返回應用類型字段，需要用戶自行選擇"
 				required
-				rules={[{ required: true, message: '应用类型不能为空' }]}
+                                rules={[{ required: true, message: '應用類型不能為空' }]}
 			>
 				<Select
 					// TODO 等 Dify 支持返回 mode 字段后，这里可以做一个判断，大于支持返回 mode 的版本就禁用，直接取接口值
 					// disabled
-					placeholder="请选择应用类型"
+                                        placeholder="請選擇應用類型"
 					options={AppModeOptions}
 				/>
 			</Form.Item>
 			<Form.Item
 				name="info.description"
-				label="应用描述"
+                                label="應用描述"
 				hidden={mode === AppDetailDrawerModeEnum.create}
 			>
 				<Input
 					disabled
-					placeholder="请输入应用描述"
+                                        placeholder="請輸入應用描述"
 				/>
 			</Form.Item>
 			<Form.Item
 				name="info.tags"
-				label="应用标签"
+                                label="應用標籤"
 				hidden={mode === AppDetailDrawerModeEnum.create}
 			>
 				{appItem?.info.tags?.length ? (
 					<div className="text-theme-text">{appItem.info.tags.join(', ')}</div>
 				) : (
-					<>无</>
+                                        <>無</>
 				)}
 			</Form.Item>
 
 			<div className="text-base mb-3 flex items-center">
 				<div className="h-4 w-1 bg-primary rounded"></div>
-				<div className="ml-2 font-semibold">对话配置</div>
+                                <div className="ml-2 font-semibold">對話配置</div>
 			</div>
 
 			<Form.Item
-				label="更新历史参数"
+                                label="更新歷史參數"
 				name="inputParams.enableUpdateAfterCvstStarts"
-				tooltip="是否允许更新历史对话的输入参数"
+                                tooltip="是否允許更新歷史對話的輸入參數"
 				rules={[{ required: true }]}
 				required
 			>
 				<Select
-					placeholder="请选择"
+                                        placeholder="請選擇"
 					options={[
 						{
-							label: '启用',
+                                                        label: '啟用',
 							value: true,
 						},
 						{
-							label: '禁用',
+                                                        label: '禁用',
 							value: false,
 						},
 					]}
@@ -135,14 +135,14 @@ export default function SettingForm(props: ISettingFormProps) {
 			</Form.Item>
 
 			<Form.Item
-				label="开场白展示场景"
+                                label="開場白展示場景"
 				name="extConfig.conversation.openingStatement.displayMode"
-				tooltip="配置开场白的展示逻辑"
+                                tooltip="配置開場白的展示邏輯"
 				rules={[{ required: true }]}
 				required
 			>
 				<Select
-					placeholder="请选择"
+                                        placeholder="請選擇"
 					options={OpeningStatementDisplayModeOptions}
 				/>
 			</Form.Item>
@@ -153,21 +153,21 @@ export default function SettingForm(props: ISettingFormProps) {
 			</div>
 
 			<Form.Item
-				label="表单回复"
+                                label="表單回覆"
 				name="answerForm.enabled"
-				tooltip="当工作流需要回复表单给用户填写时，建议开启此功能"
+                                tooltip="當工作流需要回覆表單給用戶填寫時，建議開啟此功能"
 				rules={[{ required: true }]}
 				required
 			>
 				<Select
-					placeholder="请选择"
+                                        placeholder="請選擇"
 					options={[
 						{
-							label: '启用',
+                                                        label: '啟用',
 							value: true,
 						},
 						{
-							label: '禁用',
+                                                        label: '禁用',
 							value: false,
 						},
 					]}
@@ -175,11 +175,11 @@ export default function SettingForm(props: ISettingFormProps) {
 			</Form.Item>
 			{answerFormEnabled ? (
 				<Form.Item
-					label="提交消息文本"
+                                        label="提交訊息文本"
 					name="answerForm.feedbackText"
-					tooltip="当启用表单回复时，用户填写表单并提交后，默认会以用户角色将填写的表单数据作为消息文本发送，如果配置了此字段，将会固定展示配置的字段值"
+                                        tooltip="當啟用表單回覆時，用戶填寫表單並提交後，預設會以用戶角色將填寫的表單數據作為訊息文本發送，如果配置了此字段，將會固定展示配置的字段值"
 				>
-					<Input placeholder="请输入提交消息文本" />
+                                        <Input placeholder="請輸入提交訊息文本" />
 				</Form.Item>
 			) : null}
 		</Form>

--- a/packages/react-app/src/constants/index.ts
+++ b/packages/react-app/src/constants/index.ts
@@ -3,4 +3,4 @@ export * from './storage'
 /**
  * 默认对话名称
  */
-export const DEFAULT_CONVERSATION_NAME = '新对话'
+export const DEFAULT_CONVERSATION_NAME = '新對話'

--- a/packages/react-app/src/hooks/useApi/index.ts
+++ b/packages/react-app/src/hooks/useApi/index.ts
@@ -15,9 +15,9 @@ export const useAppSiteSetting = () => {
 				})
 				.catch(err => {
 					console.error(err)
-					console.warn(
-						'Dify 版本提示: 获取应用 WebApp 设置失败，已降级为使用默认设置。如需与 Dify 配置同步，请确保你的 Dify 版本 >= v1.4.0',
-					)
+                                        console.warn(
+                                                'Dify 版本提示: 獲取應用 WebApp 設置失敗，已降級為使用默認設置。如需與 Dify 配置同步，請確保你的 Dify 版本 >= v1.4.0',
+                                        )
 					return DEFAULT_APP_SITE_SETTING
 				})
 		},

--- a/packages/react-app/src/layout/chat-layout.tsx
+++ b/packages/react-app/src/layout/chat-layout.tsx
@@ -115,7 +115,7 @@ export default function ChatLayout(props: IChatLayoutProps) {
 			}
 		} catch (error) {
 			console.error(error)
-			message.error(`获取会话列表失败: ${error}`)
+                        message.error(`獲取會話列表失敗: ${error}`)
 		} finally {
 			setCoversationListLoading(false)
 		}
@@ -167,14 +167,14 @@ export default function ChatLayout(props: IChatLayoutProps) {
 		Modal.confirm({
 			centered: true,
 			destroyOnClose: true,
-			title: '编辑对话名称',
+                        title: '編輯對話名稱',
 			content: (
 				<Form
 					form={renameForm}
 					className="mt-3"
 				>
 					<Form.Item name="name">
-						<Input placeholder="请输入" />
+                                                <Input placeholder="請輸入" />
 					</Form.Item>
 				</Form>
 			),
@@ -182,7 +182,7 @@ export default function ChatLayout(props: IChatLayoutProps) {
 				await renameForm.validateFields()
 				const values = await renameForm.validateFields()
 				await onRenameConversation(currentConversationId, values.name)
-				message.success('对话重命名成功')
+                                message.success('對話重命名成功')
 			},
 		})
 	}
@@ -221,7 +221,7 @@ export default function ChatLayout(props: IChatLayoutProps) {
 			{
 				key: 'add_conversation',
 				icon: <PlusCircleOutlined />,
-				label: '新增对话',
+                                label: '新增對話',
 				disabled: isTempId(currentConversationId),
 				onClick: () => {
 					onAddConversation()
@@ -230,7 +230,7 @@ export default function ChatLayout(props: IChatLayoutProps) {
 			{
 				key: 'rename_conversation',
 				icon: <EditOutlined />,
-				label: '编辑对话名称',
+                                label: '編輯對話名稱',
 				disabled: isTempId(currentConversationId),
 				onClick: () => {
 					handleRenameConversation()
@@ -239,20 +239,20 @@ export default function ChatLayout(props: IChatLayoutProps) {
 			{
 				key: 'delete_conversation',
 				icon: <MinusCircleOutlined />,
-				label: '删除当前对话',
+                                label: '刪除當前對話',
 				disabled: isTempId(currentConversationId),
 				danger: true,
 				onClick: () => {
 					Modal.confirm({
 						centered: true,
-						title: '确定删除当前对话？',
-						content: '删除后，聊天记录将不可恢复。',
-						okText: '删除',
+                                                title: '確定刪除當前對話？',
+                                                content: '刪除後，聊天記錄將不可恢復。',
+                                                okText: '刪除',
 						cancelText: '取消',
 						onOk: async () => {
 							// 执行删除操作
 							await onDeleteConversation(currentConversationId)
-							message.success('删除成功')
+                                                        message.success('刪除成功')
 						},
 					})
 				},
@@ -285,14 +285,14 @@ export default function ChatLayout(props: IChatLayoutProps) {
 						),
 					},
 				],
-				label: '主题',
+                                label: '主題',
 			},
 			{
 				type: 'divider',
 			},
 			{
 				type: 'group',
-				label: '对话列表',
+                                label: '對話列表',
 				children: conversations?.length
 					? conversations.map(item => {
 							return {
@@ -306,7 +306,7 @@ export default function ChatLayout(props: IChatLayoutProps) {
 					: [
 							{
 								key: 'no_conversation',
-								label: '暂无对话',
+                                                                label: '暫無對話',
 								disabled: true,
 							},
 						],
@@ -341,10 +341,10 @@ export default function ChatLayout(props: IChatLayoutProps) {
 					/>
 				) : (
 					<div className="w-full h-full flex items-center justify-center">
-						<Empty
-							className="pt-6"
-							description="暂无会话"
-						/>
+                                                <Empty
+                                                        className="pt-6"
+                                                        description="暫無會話"
+                                                />
 					</div>
 				)}
 			</Spin>
@@ -405,7 +405,7 @@ export default function ChatLayout(props: IChatLayoutProps) {
 												className="h-10 leading-10 rounded-lg border border-solid border-gray-200 mt-3 mx-4 text-theme-text "
 												icon={<PlusOutlined className="" />}
 											>
-												新增对话
+                                                                               新增對話
 											</Button>
 										) : null}
 										{/* 🌟 对话管理 */}
@@ -421,8 +421,8 @@ export default function ChatLayout(props: IChatLayoutProps) {
 										</div>
 
 										{/* 新增对话 */}
-										<Tooltip
-											title="新增对话"
+                                                                               <Tooltip
+                                                                               title="新增對話"
 											placement="right"
 										>
 											<div className="text-theme-text my-1.5 hover:text-primary flex items-center">
@@ -438,13 +438,13 @@ export default function ChatLayout(props: IChatLayoutProps) {
 											</div>
 										</Tooltip>
 
-										<Popover
-											content={
+                                                                               <Popover
+                                                                               content={
 												<div className="max-h-[50vh] overflow-auto pr-3">
 													{conversationListWithEmpty}
 												</div>
-											}
-											title="对话列表"
+                                                                               }
+                                                                               title="對話列表"
 											placement="rightTop"
 										>
 											{/* 必须包裹一个 HTML 标签才能正常展示 Popover */}
@@ -461,8 +461,8 @@ export default function ChatLayout(props: IChatLayoutProps) {
 								)}
 
 								<div className="border-0 border-t border-solid border-theme-border flex items-center justify-center h-12">
-									<Tooltip
-										title={sidebarOpen ? '折叠侧边栏' : '展开侧边栏'}
+                                                                               <Tooltip
+                                                                               title={sidebarOpen ? '折疊側邊欄' : '展開側邊欄'}
 										placement="right"
 									>
 										<div className="flex items-center justify-center">
@@ -492,10 +492,10 @@ export default function ChatLayout(props: IChatLayoutProps) {
 						</>
 					) : (
 						<div className="w-full h-full flex items-center justify-center">
-							<Empty
-								description="暂无 Dify 应用配置，请联系管理员"
-								className="text-base"
-							/>
+                                                        <Empty
+                                                                description="暫無 Dify 應用配置，請聯繫管理員"
+                                                                className="text-base"
+                                                        />
 						</div>
 					)}
 				</div>

--- a/packages/react-app/src/pages/app-list/index.tsx
+++ b/packages/react-app/src/pages/app-list/index.tsx
@@ -31,7 +31,7 @@ export default function AppListPage() {
 		{
 			manual: true,
 			onError: error => {
-				message.error(`获取应用列表失败: ${error}`)
+                            message.error(`獲取應用列表失敗: ${error}`)
 				console.error(error)
 			},
 		},
@@ -99,7 +99,7 @@ export default function AppListPage() {
 												</div>
 											</div>
 											<div className="text-sm mt-3 h-10 overflow-hidden text-ellipsis leading-5 whitespace-normal line-clamp-2 text-theme-desc">
-												{item.info.description || '暂无描述'}
+                                                                               {item.info.description || '暫無描述'}
 											</div>
 										</div>
 										<div className="flex items-center text-desc truncate mt-3 h-4">
@@ -119,7 +119,7 @@ export default function AppListPage() {
 														{
 															key: 'edit',
 															icon: <EditOutlined />,
-															label: '编辑',
+                                                                               label: '編輯',
 															onClick: () => {
 																setAppEditDrawerMode(AppDetailDrawerModeEnum.edit)
 																setAppEditDrawerOpen(true)
@@ -129,11 +129,11 @@ export default function AppListPage() {
 														{
 															key: 'delete',
 															icon: <DeleteOutlined />,
-															label: '删除',
+                                                                               label: '刪除',
 															danger: true,
 															onClick: async () => {
 																await (appService as DifyAppStore).deleteApp(item.id)
-																message.success('删除应用成功')
+                                                                               message.success('刪除應用成功')
 																getAppList()
 															},
 														},
@@ -150,7 +150,7 @@ export default function AppListPage() {
 					</Row>
 				) : (
 					<div className="w-full h-full box-border flex flex-col items-center justify-center px-3">
-						<Empty description="暂无应用" />
+                                                <Empty description="暫無應用" />
 					</div>
 				)}
 			</div>
@@ -169,7 +169,7 @@ export default function AppListPage() {
 						setAppEditDrawerAppItem(undefined)
 					}}
 				>
-					新增应用配置
+                                        新增應用配置
 				</Button>
 			) : null}
 


### PR DESCRIPTION
## Summary
- localize conversation name and app messages to Traditional Chinese
- update labels and buttons for editing, deleting, and more in Traditional Chinese
- tweak setting form placeholders and tooltips
- show config prompts in Traditional Chinese
- update warning messages

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.8.1.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_685271c02be0832e8be100f8d2dcdfdf