### PR TITLE
Convert UI to Traditional Chinese

### DIFF
--- a/packages/api/src/base-request.ts
+++ b/packages/api/src/base-request.ts
@@ -37,8 +37,8 @@ export class XRequest {
 				DIFY_INFO.version = newDifyVersion
 			}
 		}
-		if (result.status === 401) {
-			message.error('未授权, 请检查你的配置')
+                if (result.status === 401) {
+                        message.error('未授權, 請檢查你的配置')
 			throw new UnauthorizedError('Unauthorized')
 		}
 		return result

--- a/packages/components/src/chatbox/app-info.tsx
+++ b/packages/components/src/chatbox/app-info.tsx
@@ -15,7 +15,7 @@ export function AppInfo() {
 	const info4Render = useMemo(() => {
 		if (!currentApp?.config && !currentApp?.site) {
 			return {
-				name: "暂无标题",
+                                name: "暫無標題",
 				description: "",
 				tags: [],
 			};

--- a/packages/components/src/chatbox/app-input-form.tsx
+++ b/packages/components/src/chatbox/app-input-form.tsx
@@ -158,7 +158,7 @@ export default function AppInputForm(props: IAppInputFormProps) {
 				}
 				if (originalProps.required) {
 					baseProps.required = true;
-					baseProps.rules = [{ required: true, message: "请输入" }];
+                                        baseProps.rules = [{ required: true, message: "請輸入" }];
 				}
 				return baseProps;
 			}) || [],
@@ -211,7 +211,7 @@ export default function AppInputForm(props: IAppInputFormProps) {
 												? [
 														{
 															required: true,
-															message: `${item.label}不能为空`,
+                                                                               message: `${item.label}不能為空`,
 														},
 													]
 												: []
@@ -219,13 +219,13 @@ export default function AppInputForm(props: IAppInputFormProps) {
 									>
 										{item.type === "text-input" ? (
 											<Input
-												placeholder="请输入"
+                                                                               placeholder="請輸入"
 												maxLength={item.max_length}
 												disabled={disabled}
 											/>
 										) : item.type === "select" ? (
 											<Select
-												placeholder="请选择"
+                                                                               placeholder="請選擇"
 												disabled={disabled}
 												options={
 													item.options?.map((option) => {
@@ -238,13 +238,13 @@ export default function AppInputForm(props: IAppInputFormProps) {
 											/>
 										) : item.type === "paragraph" ? (
 											<Input.TextArea
-												placeholder="请输入"
+                                                                               placeholder="請輸入"
 												disabled={disabled}
 												maxLength={item.max_length}
 											/>
 										) : item.type === "number" ? (
 											<InputNumber
-												placeholder="请输入"
+                                                                               placeholder="請輸入"
 												disabled={disabled}
 												className="w-full"
 											/>
@@ -263,7 +263,7 @@ export default function AppInputForm(props: IAppInputFormProps) {
 												uploadFileApi={uploadFileApi}
 											/>
 										) : (
-											`暂不支持的控件类型: ${item.type}`
+                                                                               `暫不支持的控件類型: ${item.type}`
 										)}
 									</Form.Item>
 								);

--- a/packages/components/src/chatbox/app-input-wrapper.tsx
+++ b/packages/components/src/chatbox/app-input-wrapper.tsx
@@ -47,9 +47,9 @@ export default function AppInputWrapper(props: IAppInputFormProps) {
 			key: COLLAPSE_KEY,
 			label: (
 				<div className="flex items-center">
-					<div className="font-semibold text-base">对话参数设置</div>
+                                        <div className="font-semibold text-base">對話參數設置</div>
 					{!currentApp.config?.inputParams?.enableUpdateAfterCvstStarts ? (
-						<div className="text-desc">（注意：对话开始后，参数设置将无法修改）</div>
+                                                <div className="text-desc">（注意：對話開始後，參數設置將無法修改）</div>
 					) : null}
 				</div>
 			),

--- a/packages/components/src/chatbox/index.tsx
+++ b/packages/components/src/chatbox/index.tsx
@@ -194,8 +194,8 @@ export const Chatbox = (props: ChatboxProps) => {
 								// 直接通过遍历找到当前消息的用户子消息，取其内容发送消息
 								const currentItem = messageItems.find(item => item.id === messageItem.id)
 								if (!currentItem) {
-									console.error('消息不存在:', messageItem.id)
-									message.error('消息不存在')
+                                                                        console.error('消息不存在:', messageItem.id)
+                                                                        message.error('消息不存在')
 									return
 								}
 								onSubmit(currentItem.content, {
@@ -204,7 +204,7 @@ export const Chatbox = (props: ChatboxProps) => {
 							}}
 						/>
 						{messageItem.created_at && (
-							<div className="ml-3 text-sm text-desc">回复时间：{messageItem.created_at}</div>
+                                                        <div className="ml-3 text-sm text-desc">回覆時間：{messageItem.created_at}</div>
 						)}
 					</div>
 				),

--- a/packages/components/src/chatbox/message/footer.tsx
+++ b/packages/components/src/chatbox/message/footer.tsx
@@ -167,7 +167,7 @@ export default function MessageFooter(props: IMessageFooterProps) {
 			icon: <LucideIcon name="copy" />,
 			onClick: async () => {
 				await copyToClipboard(messageContent)
-				antdMessage.success('复制成功')
+                                antdMessage.success('複製成功')
 			},
 			active: false,
 			loading: false,

--- a/packages/components/src/chatbox/message/workflow-node-detail.tsx
+++ b/packages/components/src/chatbox/message/workflow-node-detail.tsx
@@ -23,7 +23,7 @@ export default function WorkflowNodeDetail(props: IWorkflowNodeDetailProps) {
 						className="cursor-pointer text-theme-text"
 						onClick={async () => {
 							await copyToClipboard(JSON.stringify(originalContent, null, 2))
-							message.success('复制成功')
+                                                        message.success('複製成功')
 						}}
 					/>
 					<pre className="w-full overflow-auto m-0">{JSON.stringify(originalContent, null, 2)}</pre>

--- a/packages/components/src/chatbox/thought-chain/index.tsx
+++ b/packages/components/src/chatbox/thought-chain/index.tsx
@@ -59,7 +59,7 @@ export default function ThoughtChain(props: IThoughtChainProps) {
 			title: (
 				<div className="text-base">
 					<LucideIcon name="hammer" />
-					{item.tool ? `已使用 ${item.tool}` : '暂无标题'}
+                                        {item.tool ? `已使用 ${item.tool}` : '暫無標題'}
 				</div>
 			),
 			status: 'success',
@@ -110,7 +110,7 @@ export default function ThoughtChain(props: IThoughtChainProps) {
 														className="cursor-pointer"
 														onClick={async () => {
 															await copyToClipboard(item.tool_input)
-															message.success('复制成功')
+                                                                               message.success('複製成功')
 														}}
 													/>
 												</div>
@@ -126,7 +126,7 @@ export default function ThoughtChain(props: IThoughtChainProps) {
 														className="cursor-pointer"
 														onClick={async () => {
 															await copyToClipboard(item.observation)
-															message.success('复制成功')
+                                                                               message.success('複製成功')
 														}}
 													/>
 												</div>

--- a/packages/components/src/conversation-list/index.tsx
+++ b/packages/components/src/conversation-list/index.tsx
@@ -45,7 +45,7 @@ export const ConversationList = (props: IConversationListProps) => {
 	 */
 	const deleteConversation = async (conversationId: string) => {
 		await deleteConversationPromise(conversationId)
-		message.success('删除成功')
+                message.success('刪除成功')
 	}
 
 	/**
@@ -58,14 +58,14 @@ export const ConversationList = (props: IConversationListProps) => {
 		})
 		Modal.confirm({
 			destroyOnClose: true,
-			title: '编辑对话名称',
+                        title: '編輯對話名稱',
 			content: (
 				<Form
 					form={renameForm}
 					className="mt-3"
 				>
 					<Form.Item name="name">
-						<Input placeholder="请输入" />
+                                                <Input placeholder="請輸入" />
 					</Form.Item>
 				</Form>
 			),
@@ -73,7 +73,7 @@ export const ConversationList = (props: IConversationListProps) => {
 				await renameForm.validateFields()
 				const values = await renameForm.validateFields()
 				await renameConversationPromise(conversation.key, values.name)
-				message.success('对话重命名成功')
+                                message.success('對話重命名成功')
 			},
 		})
 	}
@@ -87,12 +87,12 @@ export const ConversationList = (props: IConversationListProps) => {
 			menu={conversation => ({
 				items: [
 					{
-						label: '重命名',
+                                                label: '重命名',
 						key: 'rename',
 						icon: <EditOutlined />,
 					},
 					{
-						label: '删除',
+                                                label: '刪除',
 						key: 'delete',
 						icon: <DeleteOutlined />,
 						danger: true,

--- a/packages/components/src/markdown-renderer/blocks/image.tsx
+++ b/packages/components/src/markdown-renderer/blocks/image.tsx
@@ -23,7 +23,7 @@ export default function ImageBlock(props: IImageProps) {
 			<PhotoView src={src}>
 				<img
 					className={imgClassNames}
-					alt={alt || '图片加载失败'}
+                                        alt={alt || '圖片加載失敗'}
 					src={src}
 				/>
 			</PhotoView>

--- a/packages/components/src/markdown-renderer/index.tsx
+++ b/packages/components/src/markdown-renderer/index.tsx
@@ -226,7 +226,7 @@ const CodeBlock = memo(
 								name="copy"
 								onClick={async () => {
 									await copyToClipboard(String(children).replace(/\n$/, ""));
-									message.success("复制成功");
+                                                                        message.success("複製成功");
 								}}
 							/>
 						</Button>

--- a/packages/components/src/utils/index.ts
+++ b/packages/components/src/utils/index.ts
@@ -16,7 +16,7 @@ export const validateAndGenErrMsgs = (
 				})
 			})
 			.catch(error => {
-				console.error('表单校验失败', error)
+                                console.error('表單校驗失敗', error)
 				const errMsgs = (
 					error as {
 						errorFields: {

--- a/packages/nextjs-app/app/app/[appId]/layout/chat-layout.tsx
+++ b/packages/nextjs-app/app/app/[appId]/layout/chat-layout.tsx
@@ -189,11 +189,11 @@ export default function ChatLayout(props: IChatLayoutProps) {
 		Modal.confirm({
 			centered: true,
 			destroyOnClose: true,
-			title: "编辑对话名称",
+                        title: "編輯對話名稱",
 			content: (
 				<Form form={renameForm} className="mt-3">
 					<Form.Item name="name">
-						<Input placeholder="请输入" />
+                                                <Input placeholder="請輸入" />
 					</Form.Item>
 				</Form>
 			),
@@ -201,7 +201,7 @@ export default function ChatLayout(props: IChatLayoutProps) {
 				await renameForm.validateFields();
 				const values = await renameForm.validateFields();
 				await onRenameConversation(currentConversationId, values.name);
-				message.success("对话重命名成功");
+                                message.success("對話重命名成功");
 			},
 		});
 	};
@@ -243,7 +243,7 @@ export default function ChatLayout(props: IChatLayoutProps) {
 				{
 					key: "add_conversation",
 					icon: <PlusCircleOutlined />,
-					label: "新增对话",
+                                        label: "新增對話",
 					disabled: isTempId(currentConversationId),
 					onClick: () => {
 						onAddConversation();
@@ -252,7 +252,7 @@ export default function ChatLayout(props: IChatLayoutProps) {
 				{
 					key: "rename_conversation",
 					icon: <EditOutlined />,
-					label: "编辑对话名称",
+                                        label: "編輯對話名稱",
 					disabled: isTempId(currentConversationId),
 					onClick: () => {
 						handleRenameConversation();
@@ -261,20 +261,20 @@ export default function ChatLayout(props: IChatLayoutProps) {
 				{
 					key: "delete_conversation",
 					icon: <MinusCircleOutlined />,
-					label: "删除当前对话",
+                                        label: "刪除當前對話",
 					disabled: isTempId(currentConversationId),
 					danger: true,
 					onClick: () => {
 						Modal.confirm({
 							centered: true,
-							title: "确定删除当前对话？",
-							content: "删除后，聊天记录将不可恢复。",
-							okText: "删除",
+                                                        title: "確定刪除當前對話？",
+                                                        content: "刪除後，聊天記錄將不可恢復。",
+                                                        okText: "刪除",
 							cancelText: "取消",
 							onOk: async () => {
 								// 执行删除操作
 								await onDeleteConversation(currentConversationId);
-								message.success("删除成功");
+                                                                message.success("刪除成功");
 							},
 						});
 					},
@@ -313,14 +313,14 @@ export default function ChatLayout(props: IChatLayoutProps) {
 							),
 						},
 					],
-					label: "主题",
+                                        label: "主題",
 				},
 				{
 					type: "divider",
 				},
 				{
 					type: "group",
-					label: "对话列表",
+                                        label: "對話列表",
 					children: conversations?.length
 						? conversations.map((item) => {
 								return {
@@ -334,7 +334,7 @@ export default function ChatLayout(props: IChatLayoutProps) {
 						: [
 								{
 									key: "no_conversation",
-									label: "暂无对话",
+                                                                        label: "暫無對話",
 									disabled: true,
 								},
 							],
@@ -369,7 +369,7 @@ export default function ChatLayout(props: IChatLayoutProps) {
 					/>
 				) : (
 					<div className="w-full h-full flex items-center justify-center">
-						<Empty className="pt-6" description="暂无会话" />
+                                                <Empty className="pt-6" description="暫無會話" />
 					</div>
 				)}
 			</Spin>
@@ -437,7 +437,7 @@ export default function ChatLayout(props: IChatLayoutProps) {
 												className="h-10 leading-10 rounded-lg border border-solid border-gray-200 mt-3 mx-4 text-theme-text "
 												icon={<PlusOutlined className="" />}
 											>
-												新增对话
+                                                                               新增對話
 											</Button>
 										) : null}
 										{/* 🌟 对话管理 */}
@@ -453,7 +453,7 @@ export default function ChatLayout(props: IChatLayoutProps) {
 										</div>
 
 										{/* 新增对话 */}
-										<Tooltip title="新增对话" placement="right">
+                                                                               <Tooltip title="新增對話" placement="right">
 											<div className="text-theme-text my-1.5 hover:text-primary flex items-center">
 												<LucideIcon
 													name="plus-circle"
@@ -473,7 +473,7 @@ export default function ChatLayout(props: IChatLayoutProps) {
 													{conversationListWithEmpty}
 												</div>
 											}
-											title="对话列表"
+                                                                               title="對話列表"
 											placement="rightTop"
 										>
 											{/* 必须包裹一个 HTML 标签才能正常展示 Popover */}
@@ -490,8 +490,8 @@ export default function ChatLayout(props: IChatLayoutProps) {
 								)}
 
 								<div className="border-t border-solid border-(--theme-splitter-color) flex items-center justify-center h-12">
-									<Tooltip
-										title={sidebarOpen ? "折叠侧边栏" : "展开侧边栏"}
+                                                                        <Tooltip
+                                                                               title={sidebarOpen ? "折疊側邊欄" : "展開側邊欄"}
 										placement="right"
 									>
 										<div className="flex items-center justify-center">
@@ -526,10 +526,10 @@ export default function ChatLayout(props: IChatLayoutProps) {
 						</>
 					) : (
 						<div className="w-full h-full flex items-center justify-center">
-							<Empty
-								description="暂无 Dify 应用配置，请联系管理员"
-								className="text-base"
-							/>
+                                                        <Empty
+                                                                description="暫無 Dify 應用配置，請聯繫管理員"
+                                                                className="text-base"
+                                                        />
 						</div>
 					)}
 				</div>

--- a/packages/nextjs-app/app/app/[appId]/layout/common-layout.tsx
+++ b/packages/nextjs-app/app/app/[appId]/layout/common-layout.tsx
@@ -30,10 +30,10 @@ export default function CommonLayout(props: ICommonLayoutProps) {
 					<>{children}</>
 				) : (
 					<div className="w-full h-full flex items-center justify-center">
-						<Empty
-							description="暂无 Dify 应用配置，请联系管理员"
-							className="text-base"
-						/>
+                                                <Empty
+                                                        description="暫無 Dify 應用配置，請聯繫管理員"
+                                                        className="text-base"
+                                                />
 					</div>
 				)}
 			</div>

--- a/packages/nextjs-app/app/apps/components/app-item.tsx
+++ b/packages/nextjs-app/app/apps/components/app-item.tsx
@@ -42,7 +42,7 @@ export default function AppItem(props: IAppItemProps) {
 						</div>
 					</div>
 					<div className="text-sm mt-3 h-10 overflow-hidden text-ellipsis leading-5 whitespace-normal line-clamp-2 text-theme-desc">
-						{item.info.description || "暂无描述"}
+                                                {item.info.description || "暫無描述"}
 					</div>
 				</div>
 				<div className="flex items-center text-desc truncate mt-3 h-4">

--- a/packages/nextjs-app/app/apps/page.tsx
+++ b/packages/nextjs-app/app/apps/page.tsx
@@ -54,7 +54,7 @@ export default function AppsPage() {
 					</Row>
 				) : (
 					<div className="w-full h-full box-border flex flex-col items-center justify-center px-3">
-						<Empty description="暂无应用" />
+                                                <Empty description="暫無應用" />
 					</div>
 				)}
 			</div>

--- a/packages/nextjs-app/app/console/components/app-item-action-button.tsx
+++ b/packages/nextjs-app/app/console/components/app-item-action-button.tsx
@@ -31,17 +31,17 @@ export default function AppItemActionButton(props: { item: IDifyAppItem }) {
 								setAppEditDrawerAppItem(item);
 							},
 						},
-						{
-							key: "delete",
-							icon: <DeleteOutlined />,
-							label: "删除",
-							danger: true,
-							onClick: async () => {
-								await deleteApp(item.id);
-								message.success("删除应用成功");
-								// 重新加载列表页
-								redirect("/console");
-							},
+                                        {
+                                                key: "delete",
+                                                icon: <DeleteOutlined />,
+                                                label: "刪除",
+                                                danger: true,
+                                                onClick: async () => {
+                                                        await deleteApp(item.id);
+                                                        message.success("刪除應用成功");
+                                                        // 重新加载列表页
+                                                        redirect("/console");
+                                                },
 						},
 					],
 				}}

--- a/packages/nextjs-app/app/console/components/app-item.tsx
+++ b/packages/nextjs-app/app/console/components/app-item.tsx
@@ -43,7 +43,7 @@ export default function AppItem(props: IAppItemProps) {
 						</div>
 					</div>
 					<div className="text-sm mt-3 h-10 overflow-hidden text-ellipsis leading-5 whitespace-normal line-clamp-2 text-theme-desc">
-						{item.info.description || "暂无描述"}
+                                                {item.info.description || "暫無描述"}
 					</div>
 				</div>
 				<div className="flex items-center text-desc truncate mt-3 h-4">

--- a/packages/nextjs-app/app/console/components/setting-form.tsx
+++ b/packages/nextjs-app/app/console/components/setting-form.tsx
@@ -39,86 +39,86 @@ export default function SettingForm(props: ISettingFormProps) {
 			<Form.Item
 				label="API Base"
 				name="apiBase"
-				rules={[{ required: true, message: "API Base 不能为空" }]}
+                                rules={[{ required: true, message: "API Base 不能為空" }]}
 				tooltip="Dify API 的域名+版本号前缀，如 https://api.dify.ai/v1"
 				required
 			>
-				<Input autoComplete="new-password" placeholder="请输入 API BASE" />
+                                <Input autoComplete="new-password" placeholder="請輸入 API BASE" />
 			</Form.Item>
 			<Form.Item
 				label="API Secret"
 				name="apiKey"
 				tooltip="Dify App 的 API Secret (以 app- 开头)"
-				rules={[{ required: true, message: "API Secret 不能为空" }]}
+                                rules={[{ required: true, message: "API Secret 不能為空" }]}
 				required
 			>
 				<Input.Password
 					autoComplete="new-password"
-					placeholder="请输入 API Secret"
+                                        placeholder="請輸入 API Secret"
 				/>
 			</Form.Item>
 
 			<div className="text-base mb-3 flex items-center">
 				<div className="h-4 w-1 bg-primary rounded"></div>
-				<div className="ml-2 font-semibold">基本信息</div>
+                                <div className="ml-2 font-semibold">基本資訊</div>
 			</div>
 			<Form.Item
 				name="info.name"
-				label="应用名称"
+                                label="應用名稱"
 				hidden={mode === AppDetailDrawerModeEnum.create}
 			>
-				<Input disabled placeholder="请输入应用名称" />
+                                <Input disabled placeholder="請輸入應用名稱" />
 			</Form.Item>
 			<Form.Item
 				name="info.mode"
-				label="应用类型"
-				tooltip="小于或等于 v1.3.1 的 Dify API 不会返回应用类型字段，需要用户自行选择"
+                                label="應用類型"
+                                tooltip="小於或等於 v1.3.1 的 Dify API 不會返回應用類型字段，需要用戶自行選擇"
 				required
-				rules={[{ required: true, message: "应用类型不能为空" }]}
+                                rules={[{ required: true, message: "應用類型不能為空" }]}
 			>
 				<Select
 					// TODO 等 Dify 支持返回 mode 字段后，这里可以做一个判断，大于支持返回 mode 的版本就禁用，直接取接口值
 					// disabled
-					placeholder="请选择应用类型"
+                                        placeholder="請選擇應用類型"
 					options={AppModeOptions}
 				/>
 			</Form.Item>
 			<Form.Item
 				name="info.description"
-				label="应用描述"
+                                label="應用描述"
 				hidden={mode === AppDetailDrawerModeEnum.create}
 			>
-				<Input disabled placeholder="请输入应用描述" />
+                                <Input disabled placeholder="請輸入應用描述" />
 			</Form.Item>
 			<Form.Item
 				name="info.tags"
-				label="应用标签"
+                                label="應用標籤"
 				hidden={mode === AppDetailDrawerModeEnum.create}
 			>
 				{appItem?.info.tags?.length ? (
 					<div className="text-theme-text">{appItem.info.tags.join(", ")}</div>
 				) : (
-					<>无</>
+                                        <>無</>
 				)}
 			</Form.Item>
 
 			<div className="text-base mb-3 flex items-center">
 				<div className="h-4 w-1 bg-primary rounded"></div>
-				<div className="ml-2 font-semibold">对话配置</div>
+                                <div className="ml-2 font-semibold">對話配置</div>
 			</div>
 
 			<Form.Item
-				label="更新历史参数"
+                                label="更新歷史參數"
 				name="inputParams.enableUpdateAfterCvstStarts"
-				tooltip="是否允许更新历史对话的输入参数"
+                                tooltip="是否允許更新歷史對話的輸入參數"
 				rules={[{ required: true }]}
 				required
 			>
 				<Select
-					placeholder="请选择"
+                                        placeholder="請選擇"
 					options={[
 						{
-							label: "启用",
+                                                        label: "啟用",
 							value: true,
 						},
 						{
@@ -130,39 +130,39 @@ export default function SettingForm(props: ISettingFormProps) {
 			</Form.Item>
 
 			<Form.Item
-				label="开场白展示场景"
+                                label="開場白展示場景"
 				name="extConfig.conversation.openingStatement.displayMode"
-				tooltip="配置开场白的展示逻辑"
+                                tooltip="配置開場白的展示邏輯"
 				rules={[{ required: true }]}
 				required
 			>
 				<Select
-					placeholder="请选择"
+                                        placeholder="請選擇"
 					options={OpeningStatementDisplayModeOptions}
 				/>
 			</Form.Item>
 
 			<div className="text-base mb-3 flex items-center">
 				<div className="h-4 w-1 bg-primary rounded"></div>
-				<div className="ml-2 font-semibold">更多配置</div>
+                                <div className="ml-2 font-semibold">更多配置</div>
 			</div>
 
 			<Form.Item
-				label="表单回复"
+                                label="表單回覆"
 				name="answerForm.enabled"
-				tooltip="当工作流需要回复表单给用户填写时，建议开启此功能"
+                                tooltip="當工作流需要回覆表單給用戶填寫時，建議開啟此功能"
 				rules={[{ required: true }]}
 				required
 			>
 				<Select
-					placeholder="请选择"
+                                        placeholder="請選擇"
 					options={[
 						{
-							label: "启用",
+                                                        label: "啟用",
 							value: true,
 						},
 						{
-							label: "禁用",
+                                                        label: "禁用",
 							value: false,
 						},
 					]}
@@ -172,9 +172,9 @@ export default function SettingForm(props: ISettingFormProps) {
 				<Form.Item
 					label="提交消息文本"
 					name="answerForm.feedbackText"
-					tooltip="当启用表单回复时，用户填写表单并提交后，默认会以用户角色将填写的表单数据作为消息文本发送，如果配置了此字段，将会固定展示配置的字段值"
+                                        tooltip="當啟用表單回覆時，用戶填寫表單並提交後，預設會以用戶角色將填寫的表單數據作為訊息文本發送，如果配置了此字段，將會固定展示配置的字段值"
 				>
-					<Input placeholder="请输入提交消息文本" />
+                                        <Input placeholder="請輸入提交訊息文本" />
 				</Form.Item>
 			) : null}
 		</Form>

--- a/packages/nextjs-app/app/console/page.tsx
+++ b/packages/nextjs-app/app/console/page.tsx
@@ -41,7 +41,7 @@ export default async function AppsPage() {
 					</Row>
 				) : (
 					<div className="w-full h-full box-border flex flex-col items-center justify-center px-3">
-						<Empty description="暂无应用" />
+                                                <Empty description="暫無應用" />
 					</div>
 				)}
 			</div>

--- a/packages/nextjs-app/app/globals.css
+++ b/packages/nextjs-app/app/globals.css
@@ -1,20 +1,20 @@
 @import "tailwindcss";
 
 :root {
-	--theme-text-color: #333;
-	--theme-desc-color: #898989;
-	--theme-bg-color: #f2f4f7;
-	--theme-btn-bg-color: #fff;
-	--theme-main-bg-color: #fff;
-	--theme-border-color: #eff0f5;
-	--theme-splitter-color: #eff0f5;
-	--theme-button-border-color: #c9c9c9;
-	--theme-primary-color: #1669ee;
-	--theme-success-color: #52c41a;
-	--theme-warning-color: #faad14;
-	--theme-danger-color: #ff4d4f;
-	--theme-bubble-bg-color: #f2f4f7;
-	--theme-code-block-bg-color: #fff;
+        --theme-text-color: #4a4a4a;
+        --theme-desc-color: #6b7280;
+        --theme-bg-color: #f5f4ee;
+        --theme-btn-bg-color: #ffffff;
+        --theme-main-bg-color: #ffffff;
+        --theme-border-color: #e3e1db;
+        --theme-splitter-color: #e3e1db;
+        --theme-button-border-color: #bebebe;
+        --theme-primary-color: #3a6d70;
+        --theme-success-color: #69c081;
+        --theme-warning-color: #e6a23c;
+        --theme-danger-color: #d97c7c;
+        --theme-bubble-bg-color: #f5f4ee;
+        --theme-code-block-bg-color: #f0eee8;
 	--desc-color: #9ca3b3;
 	--eb-color: #ebebeb;
 	--warning-color: #ff5a07;
@@ -23,25 +23,25 @@
 }
 
 .dark {
-	--theme-text-color: #c9c9c9;
-	--theme-desc-color: #aaa;
-	--theme-bg-color: #000;
-	--theme-btn-bg-color: #333;
-	--theme-main-bg-color: #222;
-	--theme-border-color: #797979;
-	--theme-splitter-color: #55555555;
-	--theme-button-border-color: #c9c9c9;
-	--theme-primary-color: #1669ee;
-	--theme-success-color: #52c41a;
-	--theme-warning-color: #faad14;
-	--theme-danger-color: #ff4d4f;
-	--theme-bubble-bg-color: #424242;
-	--theme-code-block-bg-color: #222;
-	--desc-color: #aaa;
-	--eb-color: #ebebeb;
-	--warning-color: #ff5a07;
-	--primary-color: #1669ee;
-	--light-gray-color: #eff0f5;
+        --theme-text-color: #d4d4d4;
+        --theme-desc-color: #b0b0b0;
+        --theme-bg-color: #1f1f1f;
+        --theme-btn-bg-color: #333;
+        --theme-main-bg-color: #2c2c2c;
+        --theme-border-color: #666;
+        --theme-splitter-color: #444444;
+        --theme-button-border-color: #d1d1d1;
+        --theme-primary-color: #3a6d70;
+        --theme-success-color: #69c081;
+        --theme-warning-color: #e6a23c;
+        --theme-danger-color: #d97c7c;
+        --theme-bubble-bg-color: #3a3a3a;
+        --theme-code-block-bg-color: #232323;
+        --desc-color: #b0b0b0;
+        --eb-color: #ebebeb;
+        --warning-color: #e6a23c;
+        --primary-color: #3a6d70;
+        --light-gray-color: #eff0f5;
 }
 
 @theme inline {
@@ -168,7 +168,7 @@
 }
 
 body {
-	background: var(--theme-main-bg-color);
-	color: var(--theme-text-color);
-	font-family: Arial, Helvetica, sans-serif;
+        background: var(--theme-main-bg-color);
+        color: var(--theme-text-color);
+        font-family: "Noto Serif TC", Arial, serif;
 }

--- a/packages/react-app/src/App.css
+++ b/packages/react-app/src/App.css
@@ -2,34 +2,34 @@
 @tailwind utilities;
 
 :root {
-	--theme-text-color: #333;
-	--theme-desc-color: #898989;
-	--theme-bg-color: #f2f4f7;
-	--theme-btn-bg-color: #fff;
-	--theme-main-bg-color: #fff;
-	--theme-border-color: #eff0f5;
-	--theme-splitter-color: #eff0f5;
-	--theme-button-border-color: #c9c9c9;
-	--theme-primary-color: #1669ee;
-	--theme-success-color: #52c41a;
-	--theme-warning-color: #faad14;
-	--theme-danger-color: #ff4d4f;
-	--theme-bubble-bg-color: #f2f4f7;
-	--theme-code-block-bg-color: #fff;
+        --theme-text-color: #4a4a4a;
+        --theme-desc-color: #6b7280;
+        --theme-bg-color: #f5f4ee;
+        --theme-btn-bg-color: #ffffff;
+        --theme-main-bg-color: #ffffff;
+        --theme-border-color: #e3e1db;
+        --theme-splitter-color: #e3e1db;
+        --theme-button-border-color: #bebebe;
+        --theme-primary-color: #3a6d70;
+        --theme-success-color: #69c081;
+        --theme-warning-color: #e6a23c;
+        --theme-danger-color: #d97c7c;
+        --theme-bubble-bg-color: #f5f4ee;
+        --theme-code-block-bg-color: #f0eee8;
 }
 
 /* 夜间模式类名 */
 .dark {
-	--theme-text-color: #c9c9c9;
-	--theme-desc-color: #aaa;
-	--theme-bg-color: #000;
-	--theme-btn-bg-color: #333;
-	--theme-main-bg-color: #222;
-	--theme-border-color: #797979;
-	--theme-splitter-color: #55555555;
-	--theme-button-border-color: #c9c9c9;
-	--theme-bubble-bg-color: #424242;
-	--theme-code-block-bg-color: #222;
+        --theme-text-color: #d4d4d4;
+        --theme-desc-color: #b0b0b0;
+        --theme-bg-color: #1f1f1f;
+        --theme-btn-bg-color: #333;
+        --theme-main-bg-color: #2c2c2c;
+        --theme-border-color: #666;
+        --theme-splitter-color: #444444;
+        --theme-button-border-color: #d1d1d1;
+        --theme-bubble-bg-color: #3a3a3a;
+        --theme-code-block-bg-color: #232323;
 }
 
 .ant-collapse {
@@ -94,11 +94,11 @@ h3 {
 }
 
 body {
-	margin: 0;
-	color: var(--theme-text-color);
+        margin: 0;
+        color: var(--theme-text-color);
 
-	font-family: AibabaPuHuiTi, sans-serif;
-	background: white;
+        font-family: "Noto Serif TC", AibabaPuHuiTi, serif;
+        background: white;
 }
 
 a {

--- a/packages/react-app/src/components/app-edit-drawer.tsx
+++ b/packages/react-app/src/components/app-edit-drawer.tsx
@@ -68,7 +68,7 @@ export const AppEditDrawer = (props: IAppEditDrawerProps) => {
 			manual: true,
 			onSuccess: () => {
 				onClose?.()
-				message.success('新增应用配置成功')
+                                message.success('新增應用配置成功')
 			},
 		},
 	)
@@ -81,7 +81,7 @@ export const AppEditDrawer = (props: IAppEditDrawerProps) => {
 			manual: true,
 			onSuccess: () => {
 				onClose?.()
-				message.success('编辑应用配置成功')
+                                message.success('編輯應用配置成功')
 			},
 		},
 	)
@@ -89,7 +89,7 @@ export const AppEditDrawer = (props: IAppEditDrawerProps) => {
 	return (
 		<Drawer
 			width={700}
-			title={`${detailDrawerMode === AppDetailDrawerModeEnum.create ? '新增应用配置' : `编辑应用配置 - ${appItem?.info.name}`}`}
+                        title={`${detailDrawerMode === AppDetailDrawerModeEnum.create ? '新增應用配置' : `編輯應用配置 - ${appItem?.info.name}`}`}
 			open={open}
 			onClose={onClose}
 			extra={
@@ -151,14 +151,14 @@ export const AppEditDrawer = (props: IAppEditDrawerProps) => {
 								}
 								confirmCallback?.()
 							} catch (error) {
-								console.error('保存应用配置失败', error)
-								message.error(`保存应用配置失败: ${error}`)
+                                                                console.error('保存應用配置失敗', error)
+                                                                message.error(`保存應用配置失敗: ${error}`)
 							} finally {
 								setConfirmBtnLoading(false)
 							}
 						}}
 					>
-						{detailDrawerMode === AppDetailDrawerModeEnum.create ? '确定' : '更新'}
+                                                {detailDrawerMode === AppDetailDrawerModeEnum.create ? '確定' : '更新'}
 					</Button>
 				</Space>
 			}

--- a/packages/react-app/src/components/app-list.tsx
+++ b/packages/react-app/src/components/app-list.tsx
@@ -67,21 +67,21 @@ export default function AppList(props: IAppListProps) {
 									items: [
 										{
 											key: 'update',
-											label: '更新配置',
+                                                                               label: '更新配置',
 											onClick: async event => {
 												event.domEvent.stopPropagation()
 												await onUpdate?.(item.id, item)
-												message.success('更新应用配置成功')
+                                                                               message.success('更新應用配置成功')
 											},
 										},
 										{
 											key: 'delete',
-											label: '删除',
+                                                                               label: '刪除',
 											danger: true,
 											onClick: async event => {
 												event.domEvent.stopPropagation()
 												await onDelete(item.id)
-												message.success('删除应用成功')
+                                                                               message.success('刪除應用成功')
 											},
 										},
 									],

--- a/packages/react-app/src/components/chatbox-wrapper.tsx
+++ b/packages/react-app/src/components/chatbox-wrapper.tsx
@@ -294,12 +294,12 @@ export default function ChatboxWrapper(props: IChatboxWrapperProps) {
 	if (!currentApp) {
 		return (
 			<div className="w-full h-full flex items-center justify-center">
-				<Empty description="请先配置 Dify 应用">
+                                <Empty description="請先配置 Dify 應用">
 					<Button
 						type="primary"
 						onClick={handleStartConfig}
 					>
-						开始配置
+                                                開始配置
 					</Button>
 				</Empty>
 			</div>

--- a/packages/react-app/src/components/setting-form.tsx
+++ b/packages/react-app/src/components/setting-form.tsx
@@ -30,104 +30,104 @@ export default function SettingForm(props: ISettingFormProps) {
 		>
 			<div className="text-base mb-3 flex items-center">
 				<div className="h-4 w-1 bg-primary rounded"></div>
-				<div className="ml-2 font-semibold">请求配置</div>
+                                <div className="ml-2 font-semibold">請求配置</div>
 			</div>
 			<Form.Item
 				label="API Base"
 				name="apiBase"
-				rules={[{ required: true, message: 'API Base 不能为空' }]}
+                                rules={[{ required: true, message: 'API Base 不能為空' }]}
 				tooltip="Dify API 的域名+版本号前缀，如 https://api.dify.ai/v1"
 				required
 			>
 				<Input
 					autoComplete="new-password"
-					placeholder="请输入 API BASE"
+                                        placeholder="請輸入 API BASE"
 				/>
 			</Form.Item>
 			<Form.Item
 				label="API Secret"
 				name="apiKey"
-				tooltip="Dify App 的 API Secret (以 app- 开头)"
-				rules={[{ required: true, message: 'API Secret 不能为空' }]}
+                                tooltip="Dify App 的 API Secret (以 app- 開頭)"
+                                rules={[{ required: true, message: 'API Secret 不能為空' }]}
 				required
 			>
 				<Input.Password
 					autoComplete="new-password"
-					placeholder="请输入 API Secret"
+                                        placeholder="請輸入 API Secret"
 				/>
 			</Form.Item>
 
 			<div className="text-base mb-3 flex items-center">
 				<div className="h-4 w-1 bg-primary rounded"></div>
-				<div className="ml-2 font-semibold">基本信息</div>
+                                <div className="ml-2 font-semibold">基本資訊</div>
 			</div>
 			<Form.Item
 				name="info.name"
-				label="应用名称"
+                                label="應用名稱"
 				hidden={mode === AppDetailDrawerModeEnum.create}
 			>
 				<Input
 					disabled
-					placeholder="请输入应用名称"
+                                        placeholder="請輸入應用名稱"
 				/>
 			</Form.Item>
 			<Form.Item
 				name="info.mode"
-				label="应用类型"
-				tooltip="小于或等于 v1.3.1 的 Dify API 不会返回应用类型字段，需要用户自行选择"
+                                label="應用類型"
+                                tooltip="小於或等於 v1.3.1 的 Dify API 不會返回應用類型字段，需要用戶自行選擇"
 				required
-				rules={[{ required: true, message: '应用类型不能为空' }]}
+                                rules={[{ required: true, message: '應用類型不能為空' }]}
 			>
 				<Select
 					// TODO 等 Dify 支持返回 mode 字段后，这里可以做一个判断，大于支持返回 mode 的版本就禁用，直接取接口值
 					// disabled
-					placeholder="请选择应用类型"
+                                        placeholder="請選擇應用類型"
 					options={AppModeOptions}
 				/>
 			</Form.Item>
 			<Form.Item
 				name="info.description"
-				label="应用描述"
+                                label="應用描述"
 				hidden={mode === AppDetailDrawerModeEnum.create}
 			>
 				<Input
 					disabled
-					placeholder="请输入应用描述"
+                                        placeholder="請輸入應用描述"
 				/>
 			</Form.Item>
 			<Form.Item
 				name="info.tags"
-				label="应用标签"
+                                label="應用標籤"
 				hidden={mode === AppDetailDrawerModeEnum.create}
 			>
 				{appItem?.info.tags?.length ? (
 					<div className="text-theme-text">{appItem.info.tags.join(', ')}</div>
 				) : (
-					<>无</>
+                                        <>無</>
 				)}
 			</Form.Item>
 
 			<div className="text-base mb-3 flex items-center">
 				<div className="h-4 w-1 bg-primary rounded"></div>
-				<div className="ml-2 font-semibold">对话配置</div>
+                                <div className="ml-2 font-semibold">對話配置</div>
 			</div>
 
 			<Form.Item
-				label="更新历史参数"
+                                label="更新歷史參數"
 				name="inputParams.enableUpdateAfterCvstStarts"
-				tooltip="是否允许更新历史对话的输入参数"
+                                tooltip="是否允許更新歷史對話的輸入參數"
 				rules={[{ required: true }]}
 				required
 			>
 				<Select
-					placeholder="请选择"
+                                        placeholder="請選擇"
 					options={[
 						{
-							label: '启用',
+                                                        label: '啟用',
 							value: true,
 						},
 						{
-							label: '禁用',
+                                                        label: '禁用',
 							value: false,
 						},
 					]}
@@ -135,14 +135,14 @@ export default function SettingForm(props: ISettingFormProps) {
 			</Form.Item>
 
 			<Form.Item
-				label="开场白展示场景"
+                                label="開場白展示場景"
 				name="extConfig.conversation.openingStatement.displayMode"
-				tooltip="配置开场白的展示逻辑"
+                                tooltip="配置開場白的展示邏輯"
 				rules={[{ required: true }]}
 				required
 			>
 				<Select
-					placeholder="请选择"
+                                        placeholder="請選擇"
 					options={OpeningStatementDisplayModeOptions}
 				/>
 			</Form.Item>
@@ -153,21 +153,21 @@ export default function SettingForm(props: ISettingFormProps) {
 			</div>
 
 			<Form.Item
-				label="表单回复"
+                                label="表單回覆"
 				name="answerForm.enabled"
-				tooltip="当工作流需要回复表单给用户填写时，建议开启此功能"
+                                tooltip="當工作流需要回覆表單給用戶填寫時，建議開啟此功能"
 				rules={[{ required: true }]}
 				required
 			>
 				<Select
-					placeholder="请选择"
+                                        placeholder="請選擇"
 					options={[
 						{
-							label: '启用',
+                                                        label: '啟用',
 							value: true,
 						},
 						{
-							label: '禁用',
+                                                        label: '禁用',
 							value: false,
 						},
 					]}
@@ -175,11 +175,11 @@ export default function SettingForm(props: ISettingFormProps) {
 			</Form.Item>
 			{answerFormEnabled ? (
 				<Form.Item
-					label="提交消息文本"
+                                        label="提交訊息文本"
 					name="answerForm.feedbackText"
-					tooltip="当启用表单回复时，用户填写表单并提交后，默认会以用户角色将填写的表单数据作为消息文本发送，如果配置了此字段，将会固定展示配置的字段值"
+                                        tooltip="當啟用表單回覆時，用戶填寫表單並提交後，預設會以用戶角色將填寫的表單數據作為訊息文本發送，如果配置了此字段，將會固定展示配置的字段值"
 				>
-					<Input placeholder="请输入提交消息文本" />
+                                        <Input placeholder="請輸入提交訊息文本" />
 				</Form.Item>
 			) : null}
 		</Form>

--- a/packages/react-app/src/constants/index.ts
+++ b/packages/react-app/src/constants/index.ts
@@ -3,4 +3,4 @@ export * from './storage'
 /**
  * 默认对话名称
  */
-export const DEFAULT_CONVERSATION_NAME = '新对话'
+export const DEFAULT_CONVERSATION_NAME = '新對話'

--- a/packages/react-app/src/hooks/useApi/index.ts
+++ b/packages/react-app/src/hooks/useApi/index.ts
@@ -15,9 +15,9 @@ export const useAppSiteSetting = () => {
 				})
 				.catch(err => {
 					console.error(err)
-					console.warn(
-						'Dify 版本提示: 获取应用 WebApp 设置失败，已降级为使用默认设置。如需与 Dify 配置同步，请确保你的 Dify 版本 >= v1.4.0',
-					)
+                                        console.warn(
+                                                'Dify 版本提示: 獲取應用 WebApp 設置失敗，已降級為使用默認設置。如需與 Dify 配置同步，請確保你的 Dify 版本 >= v1.4.0',
+                                        )
 					return DEFAULT_APP_SITE_SETTING
 				})
 		},

--- a/packages/react-app/src/hooks/useX/index.ts
+++ b/packages/react-app/src/hooks/useX/index.ts
@@ -71,7 +71,7 @@ export const useX = (options: {
 
 			// 异常 => 结束
 			if (response.status !== 200) {
-				const errText = response.statusText || '请求对话接口失败'
+                                const errText = response.statusText || '請求對話接口失敗'
 				antdMessage.error(errText)
 				// 打断输出
 				abortRef.current = () => {
@@ -330,7 +330,7 @@ export const useX = (options: {
 		agent,
 		requestPlaceholder: () => {
 			return {
-				content: '正在回复，请耐心等待...',
+                                content: '正在回覆，請耐心等待...',
 				role: 'assistant',
 			}
 		},

--- a/packages/react-app/src/layout/chat-layout.tsx
+++ b/packages/react-app/src/layout/chat-layout.tsx
@@ -115,7 +115,7 @@ export default function ChatLayout(props: IChatLayoutProps) {
 			}
 		} catch (error) {
 			console.error(error)
-			message.error(`获取会话列表失败: ${error}`)
+                        message.error(`獲取會話列表失敗: ${error}`)
 		} finally {
 			setCoversationListLoading(false)
 		}
@@ -167,14 +167,14 @@ export default function ChatLayout(props: IChatLayoutProps) {
 		Modal.confirm({
 			centered: true,
 			destroyOnClose: true,
-			title: '编辑对话名称',
+                        title: '編輯對話名稱',
 			content: (
 				<Form
 					form={renameForm}
 					className="mt-3"
 				>
 					<Form.Item name="name">
-						<Input placeholder="请输入" />
+                                                <Input placeholder="請輸入" />
 					</Form.Item>
 				</Form>
 			),
@@ -182,7 +182,7 @@ export default function ChatLayout(props: IChatLayoutProps) {
 				await renameForm.validateFields()
 				const values = await renameForm.validateFields()
 				await onRenameConversation(currentConversationId, values.name)
-				message.success('对话重命名成功')
+                                message.success('對話重命名成功')
 			},
 		})
 	}
@@ -221,7 +221,7 @@ export default function ChatLayout(props: IChatLayoutProps) {
 			{
 				key: 'add_conversation',
 				icon: <PlusCircleOutlined />,
-				label: '新增对话',
+                                label: '新增對話',
 				disabled: isTempId(currentConversationId),
 				onClick: () => {
 					onAddConversation()
@@ -230,7 +230,7 @@ export default function ChatLayout(props: IChatLayoutProps) {
 			{
 				key: 'rename_conversation',
 				icon: <EditOutlined />,
-				label: '编辑对话名称',
+                                label: '編輯對話名稱',
 				disabled: isTempId(currentConversationId),
 				onClick: () => {
 					handleRenameConversation()
@@ -239,20 +239,20 @@ export default function ChatLayout(props: IChatLayoutProps) {
 			{
 				key: 'delete_conversation',
 				icon: <MinusCircleOutlined />,
-				label: '删除当前对话',
+                                label: '刪除當前對話',
 				disabled: isTempId(currentConversationId),
 				danger: true,
 				onClick: () => {
 					Modal.confirm({
 						centered: true,
-						title: '确定删除当前对话？',
-						content: '删除后，聊天记录将不可恢复。',
-						okText: '删除',
+                                                title: '確定刪除當前對話？',
+                                                content: '刪除後，聊天記錄將不可恢復。',
+                                                okText: '刪除',
 						cancelText: '取消',
 						onOk: async () => {
 							// 执行删除操作
 							await onDeleteConversation(currentConversationId)
-							message.success('删除成功')
+                                                        message.success('刪除成功')
 						},
 					})
 				},
@@ -285,14 +285,14 @@ export default function ChatLayout(props: IChatLayoutProps) {
 						),
 					},
 				],
-				label: '主题',
+                                label: '主題',
 			},
 			{
 				type: 'divider',
 			},
 			{
 				type: 'group',
-				label: '对话列表',
+                                label: '對話列表',
 				children: conversations?.length
 					? conversations.map(item => {
 							return {
@@ -306,7 +306,7 @@ export default function ChatLayout(props: IChatLayoutProps) {
 					: [
 							{
 								key: 'no_conversation',
-								label: '暂无对话',
+                                                                label: '暫無對話',
 								disabled: true,
 							},
 						],
@@ -341,10 +341,10 @@ export default function ChatLayout(props: IChatLayoutProps) {
 					/>
 				) : (
 					<div className="w-full h-full flex items-center justify-center">
-						<Empty
-							className="pt-6"
-							description="暂无会话"
-						/>
+                                                <Empty
+                                                        className="pt-6"
+                                                        description="暫無會話"
+                                                />
 					</div>
 				)}
 			</Spin>
@@ -405,7 +405,7 @@ export default function ChatLayout(props: IChatLayoutProps) {
 												className="h-10 leading-10 rounded-lg border border-solid border-gray-200 mt-3 mx-4 text-theme-text "
 												icon={<PlusOutlined className="" />}
 											>
-												新增对话
+                                                                               新增對話
 											</Button>
 										) : null}
 										{/* 🌟 对话管理 */}
@@ -420,9 +420,9 @@ export default function ChatLayout(props: IChatLayoutProps) {
 											<AppIcon size="small" />
 										</div>
 
-										{/* 新增对话 */}
-										<Tooltip
-											title="新增对话"
+                                       {/* 新增對話 */}
+                                                                               <Tooltip
+                                                                               title="新增對話"
 											placement="right"
 										>
 											<div className="text-theme-text my-1.5 hover:text-primary flex items-center">
@@ -438,13 +438,13 @@ export default function ChatLayout(props: IChatLayoutProps) {
 											</div>
 										</Tooltip>
 
-										<Popover
-											content={
+                                                                               <Popover
+                                                                               content={
 												<div className="max-h-[50vh] overflow-auto pr-3">
 													{conversationListWithEmpty}
 												</div>
-											}
-											title="对话列表"
+                                                                               }
+                                                                               title="對話列表"
 											placement="rightTop"
 										>
 											{/* 必须包裹一个 HTML 标签才能正常展示 Popover */}
@@ -461,8 +461,8 @@ export default function ChatLayout(props: IChatLayoutProps) {
 								)}
 
 								<div className="border-0 border-t border-solid border-theme-border flex items-center justify-center h-12">
-									<Tooltip
-										title={sidebarOpen ? '折叠侧边栏' : '展开侧边栏'}
+                                                                               <Tooltip
+                                                                               title={sidebarOpen ? '折疊側邊欄' : '展開側邊欄'}
 										placement="right"
 									>
 										<div className="flex items-center justify-center">
@@ -492,10 +492,10 @@ export default function ChatLayout(props: IChatLayoutProps) {
 						</>
 					) : (
 						<div className="w-full h-full flex items-center justify-center">
-							<Empty
-								description="暂无 Dify 应用配置，请联系管理员"
-								className="text-base"
-							/>
+                                                        <Empty
+                                                                description="暫無 Dify 應用配置，請聯繫管理員"
+                                                                className="text-base"
+                                                        />
 						</div>
 					)}
 				</div>

--- a/packages/react-app/src/layout/common-layout.tsx
+++ b/packages/react-app/src/layout/common-layout.tsx
@@ -28,10 +28,10 @@ export default function CommonLayout(props: ICommonLayoutProps) {
 					<>{children}</>
 				) : (
 					<div className="w-full h-full flex items-center justify-center">
-						<Empty
-							description="暂无 Dify 应用配置，请联系管理员"
-							className="text-base"
-						/>
+                                                <Empty
+                                                        description="暫無 Dify 應用配置，請聯繫管理員"
+                                                        className="text-base"
+                                                />
 					</div>
 				)}
 			</div>

--- a/packages/react-app/src/layout/multi-app-layout.tsx
+++ b/packages/react-app/src/layout/multi-app-layout.tsx
@@ -64,7 +64,7 @@ const MultiAppLayout = (props: IMultiAppLayoutProps) => {
 				}
 			},
 			onError: error => {
-				message.error(`获取应用列表失败: ${error}`)
+                                message.error(`獲取應用列表失敗: ${error}`)
 				console.error(error)
 			},
 		},
@@ -108,7 +108,7 @@ const MultiAppLayout = (props: IMultiAppLayoutProps) => {
 				})
 			})
 			.catch(err => {
-				message.error(`获取应用参数失败: ${err}`)
+                            message.error(`獲取應用參數失敗: ${err}`)
 				console.error(err)
 				setCurrentApp(undefined)
 			})

--- a/packages/react-app/src/pages/app-list/index.tsx
+++ b/packages/react-app/src/pages/app-list/index.tsx
@@ -31,7 +31,7 @@ export default function AppListPage() {
 		{
 			manual: true,
 			onError: error => {
-				message.error(`获取应用列表失败: ${error}`)
+                            message.error(`獲取應用列表失敗: ${error}`)
 				console.error(error)
 			},
 		},
@@ -99,7 +99,7 @@ export default function AppListPage() {
 												</div>
 											</div>
 											<div className="text-sm mt-3 h-10 overflow-hidden text-ellipsis leading-5 whitespace-normal line-clamp-2 text-theme-desc">
-												{item.info.description || '暂无描述'}
+                                                                               {item.info.description || '暫無描述'}
 											</div>
 										</div>
 										<div className="flex items-center text-desc truncate mt-3 h-4">
@@ -119,7 +119,7 @@ export default function AppListPage() {
 														{
 															key: 'edit',
 															icon: <EditOutlined />,
-															label: '编辑',
+                                                                               label: '編輯',
 															onClick: () => {
 																setAppEditDrawerMode(AppDetailDrawerModeEnum.edit)
 																setAppEditDrawerOpen(true)
@@ -129,11 +129,11 @@ export default function AppListPage() {
 														{
 															key: 'delete',
 															icon: <DeleteOutlined />,
-															label: '删除',
+                                                                               label: '刪除',
 															danger: true,
 															onClick: async () => {
 																await (appService as DifyAppStore).deleteApp(item.id)
-																message.success('删除应用成功')
+                                                                               message.success('刪除應用成功')
 																getAppList()
 															},
 														},
@@ -150,7 +150,7 @@ export default function AppListPage() {
 					</Row>
 				) : (
 					<div className="w-full h-full box-border flex flex-col items-center justify-center px-3">
-						<Empty description="暂无应用" />
+                                                <Empty description="暫無應用" />
 					</div>
 				)}
 			</div>
@@ -169,7 +169,7 @@ export default function AppListPage() {
 						setAppEditDrawerAppItem(undefined)
 					}}
 				>
-					新增应用配置
+                                        新增應用配置
 				</Button>
 			) : null}
 


### PR DESCRIPTION
## Summary
- switch remaining UI text to Traditional Chinese
- update delete menu for apps in console to show Traditional Chinese
- fix leftover Simplified Chinese in thought chain and app info sections
- tweak comment in chat layout
- apply Wenqing color theme and serif fonts

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.8.1.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_685271c02be0832e8be100f8d2dcdfdf